### PR TITLE
fix: update logo url ref link to a working one 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <br />
 <div align="center">
    <a href="https://github.com/RubyRaider/ruby_raider">
-   <img src="https://private-user-images.githubusercontent.com/33221555/391053089-3a1a492f-a70e-45ff-8fd0-5f83cef91f49.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzQxMjQ1MTEsIm5iZiI6MTczNDEyNDIxMSwicGF0aCI6Ii8zMzIyMTU1NS8zOTEwNTMwODktM2ExYTQ5MmYtYTcwZS00NWZmLThmZDAtNWY4M2NlZjkxZjQ5LnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMjEzVDIxMTAxMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWU1OGQzNzAzNzkyZDk1ODQ0NmQ5NjE4ODQ2MmU2ZDRmMzE3ZmM4NzIzNmUzMzg0YmVjNWRlYzBiNzRiOTMxOTYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.VRnGFS1lZnAeumwk5a_xiPGcEcrqpQvX-iaAwk29t-I" alt="Logo" style="width:200px;">
+   <img src="https://www.ruby-raider.com/assets/icon-DYY74ofR.png" alt="Logo" style="width:200px;">
    </a>
    <p align="center">
       <a href="https://github.com/RubyRaider/ruby_raider#getting-started"><strong>Explore the docs »</strong></a>


### PR DESCRIPTION
Updated the reference logo URL to a current one, ensuring correct display. Now uses the base project page instead, eliminating the need for frequent token updates.